### PR TITLE
Check frame if accessibilityFrame is not available in Minimum Touch Size check

### DIFF
--- a/Classes/GTXChecksCollection.m
+++ b/Classes/GTXChecksCollection.m
@@ -283,7 +283,7 @@ static const float kGTXMinContrastRatioForAccessibleText = 3.0;
     // Since UIAccessibilityElement instances don't really have a frame independent of their
     // accessibility frame, ignoring elements with frames that are not UIView subclasses solves
     // this.
-    if ([element respondsToSelector:@selector(frame)] && [element isKindOfClass:[UIView class]]) {
+    else if ([element respondsToSelector:@selector(frame)] && [element isKindOfClass:[UIView class]]) {
       [GTXChecksCollection gtx_errorDescriptionForMinimumTappableArea:[element frame]
                                                          propertyName:@"frame"
                                                            addToArray:errorDescriptions];


### PR DESCRIPTION
Check `frame` only if `accessibilityFrame` is not available. 

Right now if an element's `accessibilityFrame` is larger than the minimum tappable area but the `frame is smaller than the minimum tappable area, the check fails. This can occur if a developer decides to update the `accessibilityFrame` instead of the `frame`. 

This failure causes inconsistent results between GTXiLib and Apple's Accessibility Inspector Audit.