### PR TITLE
Correct find_if_not predicate compile error.

### DIFF
--- a/OOPClasses/string_utils.cc
+++ b/OOPClasses/string_utils.cc
@@ -19,12 +19,13 @@
 namespace gtx {
 
 std::string TrimWhitespace(std::string str) {
-  auto first_nonwhitespace_iter =
-      std::find_if_not(str.begin(), str.end(), std::isspace);
+  auto first_nonwhitespace_iter = std::find_if_not(
+      str.begin(), str.end(), [](char c) { return std::isspace(c); });
   auto trimmed_leading = str.substr(first_nonwhitespace_iter - str.begin(),
                                     str.end() - first_nonwhitespace_iter);
-  auto last_nonwhitespace_iter = std::find_if_not(
-      trimmed_leading.rbegin(), trimmed_leading.rend(), std::isspace);
+  auto last_nonwhitespace_iter =
+      std::find_if_not(trimmed_leading.rbegin(), trimmed_leading.rend(),
+                       [](char c) { return std::isspace(c); });
   return trimmed_leading.substr(
       0, trimmed_leading.rend() - last_nonwhitespace_iter);
 }


### PR DESCRIPTION
Corrects the following error:
libc++/trunk/include/algorithm:954:1: note: candidate template ignored: couldn't infer template argument '_Predicate'
find_if_not(_InputIterator __first, _InputIterator __last, _Predicate __pred)