### PR TITLE
[gtxilib/cleanup] Delete duplicate implementation of -[NSObject gtx_logProperties] 🧹

### DIFF
--- a/Classes/ObjCPP/NSObject+GTXAdditions.mm
+++ b/Classes/ObjCPP/NSObject+GTXAdditions.mm
@@ -241,40 +241,4 @@
   return classNames;
 }
 
-- (NSArray<GTXLogProperty *> *)gtx_logProperties {
-  return @[
-    [GTXLogProperty propertyWithName:@"isAXElement"
-              isDeveloperLogProperty:NO
-                     descriptorBlock:^(NSObject *object) {
-                       BOOL isAccessibilityElement =
-                           [object respondsToSelector:@selector(isAccessibilityElement)]
-                               ? [object isAccessibilityElement]
-                               : NO;
-                       return isAccessibilityElement ? @"YES" : @"NO";
-                     }],
-    [GTXLogProperty propertyWithName:@"AXID"
-              isDeveloperLogProperty:NO
-                     descriptorBlock:^(NSObject *object) {
-                       return [object respondsToSelector:@selector(accessibilityIdentifier)]
-                                  ? [object performSelector:@selector(accessibilityIdentifier)]
-                                  : nil;
-                     }],
-    [GTXLogProperty propertyWithName:@"AXLabel"
-              isDeveloperLogProperty:YES
-                     descriptorBlock:^(NSObject *object) {
-                       return [object respondsToSelector:@selector(accessibilityLabel)]
-                                  ? [object accessibilityLabel]
-                                  : nil;
-                     }],
-    [GTXLogProperty propertyWithName:@"AXFrame"
-              isDeveloperLogProperty:NO
-                     descriptorBlock:^(NSObject *object) {
-                       if ([object respondsToSelector:@selector(accessibilityFrame)]) {
-                         return NSStringFromCGRect([object accessibilityFrame]);
-                       }
-                       return (NSString *)nil;
-                     }],
-  ];
-}
-
 @end


### PR DESCRIPTION
Prior to this change, -[NSObject gtx_logProperties] was implemented in
two source files:
• Classes/NSObject+GTXLogging.m
• Classes/ObjCPP/NSObject+GTXAdditions.mm

This results in a linker warning due to category method collision.

Classes/NSObject+GTXLogging.h actually declares the category method
-gtx_logProperties whereas Classes/ObjCPP/NSObject+GTXAdditions.h does
not. Classes/NSObject+GTXLogging.m also contains nothing apart from the
implementation of -[NSObject gtx_logProperties] whereas
Classes/ObjCPP/NSObject+GTXAdditions.mm contains the implementations of
numerous methods. These facts seem to imply that
Classes/NSObject+GTXLogging.m was primarily purposed for the
implementation of -[NSObject gtx_logProperties] and would not exist
otherwise. To resolve this conflict, this change proposes to delete the
duplicate from Classes/ObjCPP/NSObject+GTXAdditions.mm.